### PR TITLE
MD20241230-01 removing dependency on inc/ folder

### DIFF
--- a/asciiArtTitle.c
+++ b/asciiArtTitle.c
@@ -7,7 +7,7 @@
 #include <stdio.h>
 
 //include my custom terminal control header
-#include "inc/terminalControl.h"
+#include "terminalControl.h"
 
 //start of main method
 int main(int argc, char** argv){

--- a/cursorReadingTutorial.c
+++ b/cursorReadingTutorial.c
@@ -10,7 +10,7 @@
 #include <stdlib.h>
 
 //include my header to manipulate the terminal
-#include "inc/terminalControl.h"
+#include "terminalControl.h"
 
 //macro definiton for character used to escape program loop
 #define ESCAPECHAR 'q'

--- a/makefile
+++ b/makefile
@@ -6,7 +6,7 @@ all: snake rawModeExample cursorReadingTutorial asciiArtTitle
 
 #removes all executables in the binary folder 
 clean: 
-	@-rm ./bin/*.exe > /dev/null || true
+	@-rm ./bin/*.exe 2> /dev/null || true
 
 #rule to make the snake executable
 snake: snake.c

--- a/makefile
+++ b/makefile
@@ -1,3 +1,6 @@
+CXX		 = gcc
+CXXFLAGS = -iquote ./include
+
 #rule to make all executables
 all: snake rawModeExample cursorReadingTutorial asciiArtTitle
 
@@ -7,15 +10,15 @@ clean:
 
 #rule to make the snake executable
 snake: snake.c
-	gcc -o ./bin/snake.exe snake.c
+	$(CXX) $(CXXFLAGS) -o ./bin/snake.exe snake.c
 
 #rule to make the example raw mode program
 rawModeExample: rawModeExample.c
-	gcc -o ./bin/rawModeExample.exe rawModeExample.c
+	$(CXX) $(CXXFLAGS) -o ./bin/rawModeExample.exe rawModeExample.c
 
 #rule to make example program for cursor position reporting
 cursorReadingTutorial: cursorReadingTutorial.c
-	gcc -o ./bin/cursorReadingTutorial.exe cursorReadingTutorial.c
+	$(CXX) $(CXXFLAGS) -o ./bin/cursorReadingTutorial.exe cursorReadingTutorial.c
 
 asciiArtTitle: asciiArtTitle.c
-	gcc -o ./bin/asciiArtTitle.exe asciiArtTitle.c
+	$(CXX) $(CXXFLAGS) -o ./bin/asciiArtTitle.exe asciiArtTitle.c

--- a/rawModeExample.c
+++ b/rawModeExample.c
@@ -7,7 +7,7 @@
 #include <stdlib.h>
 
 //include my custom made library to ease terminal configuration
-#include "inc/terminalControl.h" 
+#include "terminalControl.h" 
 
 //macro for escape character to terminate the program once read
 #define escapeChar 'q' 

--- a/snake.c
+++ b/snake.c
@@ -10,10 +10,10 @@
 #include <time.h>
 
 //custom terminal control header
-#include "inc/terminalControl.h"
+#include "terminalControl.h"
 
 //custom snake game header
-#include "inc/snake.h"
+#include "snake.h"
 
 // MD20241229-04 custom snake error codes
 #include "errors.h"


### PR DESCRIPTION
@matas-noreika 
MD20241230-01
I have made some changes in respect of the included .h files

1. I have renamed the **inc/** folder to **include/**
2. I have added a gcc definition for the compiler to use, **$(CXX)**, to indicate that **makefle** should use **gcc** (as it was, but hard-coded) 
3. I have added a gcc definition for the compiler to use, **$(CXXFLAGS)**, to indicate that **makefile** should use the flag **-iquote** to specify where to find our own include files **include/**
4. In the .c files I have changed all references to "inc/...." to remove referenceces to the **inc** (or even to the **include**) directory.

