### PR TITLE
MD20250104-01 MD20250104-02 MD20250104-03

### DIFF
--- a/asciiArtTitle.c
+++ b/asciiArtTitle.c
@@ -9,6 +9,12 @@
 //include my custom terminal control header
 #include "terminalControl.h"
 
+// MD202501-04 define the name of the file to open 
+// This, of course might be replaced with a command-line argument
+// indicating the file we wish to display.
+// Now, where have I seen that before? 
+#define FileArtName "title.txt"
+
 //start of main method
 int main(int argc, char** argv){
 
@@ -33,13 +39,15 @@ int main(int argc, char** argv){
 	FILE* titleFile;
 
 	//open the title art for reading and check if the opening failed
-	if( (titleFile = fopen("title.txt", "r")) == NULL){
+	if( (titleFile = fopen(FileArtName, "r")) == NULL){
 	
 		return 2;//failed to open file
 	
-	}
+	} // iMD20250104-01 error checking for attempt to open the file
+	// MD20250104-01 note I have moved the definition of th file
+	// name to a global #define above
 
-	//intitalise read buffer
+	// declare read buffer
 	char buffer[256];
 	
 	//loop until end of file character is reached
@@ -52,9 +60,10 @@ int main(int argc, char** argv){
 		printf("%s", buffer);
 
 	}while(!(feof(titleFile)));
+	// continue as long as we have not yet reached end of file 
 
 	fclose(titleFile);//close the file once reading is complete
 
 	return 0;//return exit code indicating program was successful
 
-}
+} // MD20250104-01 end main nmethod for asciiArtTitle

--- a/include/snake_helpers.h
+++ b/include/snake_helpers.h
@@ -89,13 +89,15 @@ struct snakePart {
 void createGameArea();
 
 //decleration of getDirection()
-int getDirection();
+// MD20250104-03 Addressing declaration and definition conflicts
+int getDirection(char *);
 
 //decleration of printTitle()
 void printTitle();
 
 //decleration of addLenght()
-void addLenght();
+// MD20250104-03 Addressing declaration and definition conflicts
+void addLenght(struct snakePart*, int*, int);
 
 //decleration of moveSnake()
 int moveSnake();
@@ -104,7 +106,8 @@ int moveSnake();
 void pickRandomLocation();
 
 //decleration of addFruit()
-void addFruit();
+// MD20250104-03 Addressing declaration and definition conflicts
+void addFruit(struct snakePart*, struct snakePart*, int);
 
 //decleration of changePos()
 void changePos();

--- a/include/terminalControl.h
+++ b/include/terminalControl.h
@@ -54,7 +54,8 @@
 #define SET_OUTPUT_FAIL -7
 
 //function to return the terminal row & column size
-int getTerminalSize();	
+// MD20250104-02 Fixing disparities in function declarations
+int getTerminalSize(int*, int*);	
 	
 //function to store the current terminal settings into target platform variable location
 //this function must be called prior enterRawMode()
@@ -69,7 +70,9 @@ void exitRawMode();
 	
 //function to read from terminal input buffer independent of platform
 //returns the read size as max int size in current system to avoid conflict with ssize_t on other platforms 
-intmax_t readTerminalInput();
+// MD20250104-02 Fixing disparities in function declarations
+intmax_t readTerminalInput(char*);
 
 //function to use ANSI escape codes to retrieve the cursor position
-int readCursorPos();
+// MD20250104-02 Fixing disparities in function declarations
+int readCursorPos(int*, int*);

--- a/terminalControl.c
+++ b/terminalControl.c
@@ -327,7 +327,7 @@ intmax_t readTerminalInput(char buffer[4096]){
 } // end function to read from terminal input buffer independent of platform
 
 //function to use ANSI escape codes to retrieve the cursor position
-int readCursorPos(int*x, int* y){
+int readCursorPos(int* x, int* y){
 	
 	//decleration of readBuffer
 	char buffer[4096];


### PR DESCRIPTION
@matas-noreika 
Two issues here.
MD20250104-01 addresses minor issues in asciiArtTitle 
MD20250104-02 addresses more significant issues to do with discrepancies between the declaration of functions in terminalControl.h and their definition in terminalControl.c In the case of terminalControl.h the functions did not indicate any parameters but in terminalContrrol.c they did have parameters.

Added a third commit
MD20250104-03 Continuing to address the discrepancies between the declaration of functions in snake_helpers.h and snake_helpers.c
