### PR TITLE
MD20250105-01 Reinstating parameter types in function declarations

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "terminalcontrol.h": "c"
+    }
+}

--- a/include/snake_helpers.h
+++ b/include/snake_helpers.h
@@ -100,23 +100,23 @@ void printTitle();
 void addLenght(struct snakePart*, int*, int);
 
 //decleration of moveSnake()
-int moveSnake();
+int moveSnake(struct snakePart*, struct snakePart*, int*, int, clock_t*);
 
 //decleration of pickRandomLocation()
-void pickRandomLocation();
+void pickRandomLocation(struct snakePart*);
 
 //decleration of addFruit()
 // MD20250104-03 Addressing declaration and definition conflicts
 void addFruit(struct snakePart*, struct snakePart*, int);
 
 //decleration of changePos()
-void changePos();
+void changePos(struct snakePart* , int,  int);
 
 //decleration of updateOtherParts()
-void updateOtherParts();
+void updateOtherParts(struct snakePart*, int);
 
 //decleration of saveHighscore()
-int saveHighscore();
+int saveHighscore(int);
 
 // declaration of getHighScore
 int getHighscore();

--- a/snake_helpers.c
+++ b/snake_helpers.c
@@ -124,28 +124,28 @@ void printTitle(void){
 //definition of function to add to snake lenght
 //Matas - relocated addLenght() to header for less clutter in snake.c
 //Matas - added additional argument to function to pass current snake lenght and snake variable
-void addLenght(struct snakePart snake[MAXSNAKESIZE], int* lenght, int direction){
+void addLenght(struct snakePart snake[MAXSNAKESIZE], int* p_lenght, int direction){
 
-	*lenght += 1;//incrament the lenght variable
+	*(p_lenght) += 1;//incrament the lenght variable
 	
 	//we do a switch case on direction to determine where new snake part should spawn relative to previous snake part
 	switch(direction){
 	
 		case 1://we are moving up
-			snake[*lenght-1].xPos = snake[*lenght-2].xPos + 1;
-		       	snake[*lenght-1].yPos = snake[*lenght-2].yPos;	
+			snake[*p_lenght-1].xPos = snake[*p_lenght-2].xPos + 1;
+		       	snake[*p_lenght-1].yPos = snake[*p_lenght-2].yPos;	
 			break;
 		case 2://we are moving down
-			snake[*lenght-1].xPos = snake[*lenght-2].xPos - 1;
-			snake[*lenght-1].yPos = snake[*lenght-2].yPos;
+			snake[*p_lenght-1].xPos = snake[*p_lenght-2].xPos - 1;
+			snake[*p_lenght-1].yPos = snake[*p_lenght-2].yPos;
 			break;
 		case 3://we are moving left
-			snake[*lenght-1].xPos = snake[*lenght-2].xPos;
-			snake[*lenght-1].yPos = snake[*lenght-2].yPos - 1;
+			snake[*p_lenght-1].xPos = snake[*p_lenght-2].xPos;
+			snake[*p_lenght-1].yPos = snake[*p_lenght-2].yPos - 1;
 			break;
 		case 4://we are moving right
-			snake[*lenght-1].xPos = snake[*lenght-2].xPos;
-			snake[*lenght-1].yPos = snake[*lenght-2].yPos + 1;
+			snake[*p_lenght-1].xPos = snake[*p_lenght-2].xPos;
+			snake[*p_lenght-1].yPos = snake[*p_lenght-2].yPos + 1;
 			break;
 
 	}

--- a/snake_helpers.c
+++ b/snake_helpers.c
@@ -6,7 +6,7 @@
 //include the variable and function definitions of the snake_helpers header
 #include "snake_helpers.h"
 
-//definition of function to generate the game area
+/* definition of function to generate the game area */
 void createGameArea(void){
 	
 	//loop through all the game area rows


### PR DESCRIPTION
@matas-noreika 
In MD20250105-01 I have reinstated the parameter types in the function declarations in snake_helpers.h
Strictly, it is ok to have the parameters named on the declarations in the .h files **_as well as_** in the definitions in the .c files.
The reason that I prefer not to is that, if you change the name of the parameter in the .c file when defining the funciton, then it can be inconsistent with the declaration in the .h file, unless you remember to also chanbge that.
It is a bit of an obscure issue, but we might see more value to this approach later.

In MD20250105-02 I have repalced parameter **_int* length_** with _**int* p_length**_ (the p_ being for pointer).
This is not essential to implement universally across all of your code, but it helkps clarify, within the function definition, where we are accessing a variable via a pointer or accessing it directly as a variable.
